### PR TITLE
Video mover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ node_modules/
 src/sass/bourbon/
 bower_components/
 npm-debug.log
+src/_site/siteart/
 *.DS_Store

--- a/gulpfile.babel.js/index.js
+++ b/gulpfile.babel.js/index.js
@@ -116,13 +116,16 @@ const {
     input: videofolder
   },
   images: {
-    output: imagesFolder
+    src: imgSource
+  },
+  slides: {
+    src: slidesSource
   }
 } = paths;
 
 function watchTask() {
   watch(
-    [inputCSS, inputInlineCSS, inputJS, inlineJS, includesInput, layoutsInput, pagesInput, markdown, videofolder, imagesFolder],
+    [inputCSS, inputInlineCSS, inputJS, inlineJS, includesInput, layoutsInput, pagesInput, markdown, videofolder, imgSource, slidesSource],
     series(parallel(cleanCSS, cleanJS, cleanPages), parallel(css, cssInline), parallel(concatJs, minifyInlineScripts), cachebustScripts, parallel(includes, layouts, pages, collections), parallel(syncImages, videos))
   );
 }

--- a/gulpfile.babel.js/index.js
+++ b/gulpfile.babel.js/index.js
@@ -21,7 +21,7 @@ const { minifyInlineScripts } = require("./js_modules/minifyinlinescripts")
 const { bower } = require("./movers/bower")
 const { collections } = require("./movers/collections")
 const { videos } = require("./movers/videos")
-const { images } = require("./movers/images")
+const { syncImages } = require("./movers/syncImages")
 
 // fonts
 const { fonts } = require("./util/fonts")
@@ -33,6 +33,7 @@ const { blogImages } = require("./visuals/blogimages")
 const { heroImages } = require("./visuals/heroimages")
 const { heroIndex } = require("./visuals/heroimagesindex")
 const { slideImages } = require("./visuals/slides")
+const { embeddedImages } = require("./visuals/embeddedImages")
 
 // other
 const { animations } = require("./animations")
@@ -71,7 +72,7 @@ exports.minifyInlineScripts = minifyInlineScripts;
 exports.bower = bower;
 exports.collections = collections;
 exports.videos = videos;
-exports.images = images;
+exports.syncImages = syncImages;
 // visuals
 exports.svg = svg;
 exports.portfolioSVG = portfolioSVG;
@@ -79,6 +80,7 @@ exports.blogImages = blogImages;
 exports.heroImages = heroImages;
 exports.heroIndex = heroIndex;
 exports.slideImages = slideImages;
+exports.embeddedImages = embeddedImages;
 // other
 exports.deploy = deploy;
 exports.animations = animations;
@@ -121,7 +123,7 @@ const {
 function watchTask() {
   watch(
     [inputCSS, inputInlineCSS, inputJS, inlineJS, includesInput, layoutsInput, pagesInput, markdown, videofolder, imagesFolder],
-    series(parallel(cleanCSS, cleanJS, cleanPages), parallel(css, cssInline), parallel(concatJs, minifyInlineScripts), cachebustScripts, parallel(includes, layouts, pages, collections), parallel(images, videos))
+    series(parallel(cleanCSS, cleanJS, cleanPages), parallel(css, cssInline), parallel(concatJs, minifyInlineScripts), cachebustScripts, parallel(includes, layouts, pages, collections), parallel(syncImages, videos))
   );
 }
 

--- a/gulpfile.babel.js/movers/moveImages.js
+++ b/gulpfile.babel.js/movers/moveImages.js
@@ -21,7 +21,7 @@ function cleanImages(cb) {
         .pipe(cleanFiles())
         cb();
 }
-
+  
 exports.moveImages = series(moveImages, cleanImages);
 
 

--- a/gulpfile.babel.js/movers/syncImages.js
+++ b/gulpfile.babel.js/movers/syncImages.js
@@ -3,28 +3,22 @@ const del = require('del');
 import { paths } from "../variables"
 
 //images
-const imagemin = require('gulp-imagemin');
-const jpegtran = require('imagemin-jpegtran');
 const gm = require('gulp-gm');
-const rename = require('gulp-rename');
 
 const {
     images: {
-        output: output,
+        src: source,
         testing: testing,
         dist: dist,
     }
 } = paths;
 
-
 const cleanImages = () => del([`${testing}/{*.jpg,*.tiff,*.png}`, `${dist}/{*.jpg,*.tiff,*.png}`], { force: true });
 
-
-function moveImages(done) {
-    console.log("move")
-    return src([`${output}/{*.jpg,*.tiff,*.png}`])
+function syncImages(done) {
+    return src(`${source}/{*.jpg,*.tiff,*.png}`)
     .pipe(dest(testing))
     .pipe(dest(dist));
 }
 
-exports.images = series(cleanImages, moveImages);
+exports.syncImages = series(cleanImages, syncImages);

--- a/gulpfile.babel.js/movers/syncImages.js
+++ b/gulpfile.babel.js/movers/syncImages.js
@@ -7,18 +7,31 @@ const gm = require('gulp-gm');
 
 const {
     images: {
-        src: source,
-        testing: testing,
-        dist: dist,
-    }
+        src: imgSource,
+        testing: imgTesting,
+        dist: imgDist,
+    },
+    slides: {
+        src: slideSource,
+        testing: slideTesting,
+        dist: slideDist,
+    },
 } = paths;
 
-const cleanImages = () => del([`${testing}/{*.jpg,*.tiff,*.png}`, `${dist}/{*.jpg,*.tiff,*.png}`], { force: true });
+const cleanImages = () => del([`${imgTesting}/{*.jpg,*.tiff,*.png}`, `${imgDist}/{*.jpg,*.tiff,*.png}`], { force: true });
 
-function syncImages(done) {
-    return src(`${source}/{*.jpg,*.tiff,*.png}`)
-    .pipe(dest(testing))
-    .pipe(dest(dist));
+const syncImages = (done) => {
+    return src(`${imgSource}/{*.jpg,*.tiff,*.png}`)
+    .pipe(dest(imgTesting))
+    .pipe(dest(imgDist));
 }
 
-exports.syncImages = series(cleanImages, syncImages);
+const cleanSlides = () => del([`${slideTesting}/{*.jpg,*.tiff,*.png}`, `${slideDist}/{*.jpg,*.tiff,*.png}`], { force: true });
+
+const syncSlides = (done) => {
+    return src(`${slideSource}/{*.jpg,*.tiff,*.png}`)
+    .pipe(dest(slideTesting))
+    .pipe(dest(slideDist));
+}
+
+exports.syncImages = series(cleanImages, cleanSlides, syncImages, syncSlides);

--- a/gulpfile.babel.js/variables.js
+++ b/gulpfile.babel.js/variables.js
@@ -61,6 +61,7 @@ const paths = {
     slides: {
         input: 'src/slides_in/{*.jpg,*.tiff,*.png}',
         output: 'src/slides_out/',
+        src: 'src/_site/siteart/slides/',
         testing: 'test/siteart/slides',
         dist: 'dist/siteart/slides'
     },  

--- a/gulpfile.babel.js/variables.js
+++ b/gulpfile.babel.js/variables.js
@@ -54,6 +54,7 @@ const paths = {
     images: {
         input: 'src/photos_in/{*.jpg,*.tiff,*.png}',
         output: 'src/photos_out/',
+        src: 'src/_site/siteart/',
         testing: 'test/siteart/',
         dist: 'dist/siteart/'
     },
@@ -64,7 +65,7 @@ const paths = {
         dist: 'dist/siteart/slides'
     },  
     videos: {
-        input: 'src/videos/{*.mov,*.mp4}',
+        input: 'src/videos/{*.mov,*.mp4}', 
         testing: 'test/videos/',
         dist: 'dist/videos/'
     },  

--- a/gulpfile.babel.js/visuals/blogimages.js
+++ b/gulpfile.babel.js/visuals/blogimages.js
@@ -4,7 +4,7 @@ import { moveImages } from "../movers/moveImages"
 
 //images
 const imagemin = require('gulp-imagemin');
-const jpegtran = require('imagemin-jpegtran');
+const jpegtran = require('imagemin-jpegtran'); 
 const gm = require('gulp-gm');
 const rename = require('gulp-rename');
 

--- a/gulpfile.babel.js/visuals/blogimages.js
+++ b/gulpfile.babel.js/visuals/blogimages.js
@@ -11,8 +11,7 @@ const rename = require('gulp-rename');
 const {
     images: {
         input: input,
-        testing: test,
-        dist: dist,
+        src: source
     }
 } = paths;
 
@@ -47,8 +46,7 @@ function blogImagesLarge(done) {
             prefix: 'large_'
         }))
 
-        .pipe(dest(test))
-        .pipe(dest(dist));
+        .pipe(dest(source));
         done();
     }
 
@@ -80,8 +78,7 @@ function blogImagesXSmall(done) {
             prefix: 'xsmall_'
         }))
 
-        .pipe(dest(test))
-        .pipe(dest(dist));
+        .pipe(dest(source));
         done()
 }
 
@@ -113,8 +110,7 @@ function blogImagesMed(done) {
             prefix: 'med_'
         }))
 
-        .pipe(dest(test))
-        .pipe(dest(dist));
+        .pipe(dest(source));
         done()
 }
 

--- a/gulpfile.babel.js/visuals/embeddedImages.js
+++ b/gulpfile.babel.js/visuals/embeddedImages.js
@@ -1,0 +1,49 @@
+const { src, dest, parallel, series } = require('gulp');
+import { paths } from "../variables"
+import { moveImages } from "../movers/moveImages"
+
+//images
+const imagemin = require('gulp-imagemin');
+const jpegtran = require('imagemin-jpegtran');
+const gm = require('gulp-gm');
+
+const {
+    images: {
+        input: input,
+        src: source
+    }
+} = paths;
+
+exports.moveImages = moveImages;
+
+// Large images
+function imagesProcess(done) {
+    return src(input)
+        .pipe(gm(function (gmfile) {
+            return gmfile.setFormat('jpg'),
+                gmfile.resample(144, 144),
+                gmfile.quality(82),
+                gmfile.filter('triangle'),
+                gmfile.unsharp('0.25x0.25+8+0.065'),
+                gmfile.interlace('none'),
+                gmfile.colorspace('sRGB'),
+                gmfile.resize(700) // Resize to 1400px width, auto height
+        }, 
+        {
+            imageMagick: true
+        }
+        ))
+
+        // Crunches Images
+        .pipe(imagemin({
+            progressive: true,
+            use: [jpegtran()]
+        }))
+
+        .pipe(dest(source));
+        done();
+    }
+
+exports.embeddedImages = series(parallel(imagesProcess), series(moveImages));
+
+

--- a/gulpfile.babel.js/visuals/slides.js
+++ b/gulpfile.babel.js/visuals/slides.js
@@ -11,10 +11,10 @@ const rename = require('gulp-rename');
 const {
     slides: {
         input: input,
-        testing: test,
-        dist: dist,
+        src: source
     }
 } = paths;
+
 
 exports.moveSlides = moveSlides;
 
@@ -45,8 +45,7 @@ function slideImagesLarge(done) {
         .pipe(rename({
             prefix: 'large_'
         }))
-        .pipe(dest(test))
-        .pipe(dest(dist));
+        .pipe(dest(source));
         done();
     }
 
@@ -80,8 +79,7 @@ function slideImagesMed(done) {
             prefix: 'med_'
         }))
 
-        .pipe(dest(test))
-        .pipe(dest(dist));
+        .pipe(dest(source));
         done();
     }
 
@@ -113,8 +111,7 @@ function slideImagesSmall(done) {
             prefix: 'small_'
         }))
 
-        .pipe(dest(test))
-        .pipe(dest(dist));
+        .pipe(dest(source));
         done()
 }
 


### PR DESCRIPTION
Refactors the flow for handling photos. Photos are processed and put into the src/_site/siteart. 
Refactors the flow for handling slides. Photos are processed and put into the src/_site/siteart./slides
Adds a syncImages task that moves items for these two source folders into the test and dist folders. 
Updates index and variables files to support these changes. 